### PR TITLE
Support absolute paths in .fx-build-dir

### DIFF
--- a/src/fuchsia_paths.ts
+++ b/src/fuchsia_paths.ts
@@ -101,7 +101,8 @@ async function _readBuildDirDoc(
     const buildDirDoc = await vscode.workspace.openTextDocument(buildDirFileUri);
     let buildDir = buildDirDoc.getText().trim();
     // buildDir can be an absolute path; make it relative to folderUri.fsPath.
-    if (buildDir.startsWith(`${folderUri.fsPath}/`) {
+    if (buildDir.startsWith(`${folderUri.fsPath}/`)) {
+
         buildDir = buildDir.substring(folderUri.fsPath.length + 1);
     }
     log.info(

--- a/src/fuchsia_paths.ts
+++ b/src/fuchsia_paths.ts
@@ -99,7 +99,11 @@ async function _readBuildDirDoc(
   const buildDirFileUri = folderUri.with({ path: `${folderUri.path}/${buildDirFilename}` });
   try {
     const buildDirDoc = await vscode.workspace.openTextDocument(buildDirFileUri);
-    const buildDir = buildDirDoc.getText().trim();
+    let buildDir = buildDirDoc.getText().trim();
+    // buildDir can be an absolute path; make it relative to folderUri.fsPath.
+    if (buildDir.startsWith(`${folderUri.fsPath}/`) {
+        buildDir = buildDir.substring(folderUri.fsPath.length + 1);
+    }
     log.info(
       `Folder '${folderUri.fsPath}' contains the '${buildDirFilename}' file, ` +
       `which specifies that the current Fuchsia build directory is '${buildDir}'`


### PR DESCRIPTION
According to [1], the path in .fx-build-dir can be absolute.

[1] https://cs.opensource.google/fuchsia/fuchsia/+/main:tools/devshell/lib/vars.sh;l=142;drc=177f2940747db40d498ad4ef2442cd8f78edb965