### PR TITLE
Image URLs require vsce flag for main branch

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -69,7 +69,7 @@ if not already present.)
 
    ```shell
    $ vsce package
-   $ vsce publish <patch or minor or simply $NEW_VERSION>
+   $ vsce publish <patch or minor or simply $NEW_VERSION> --githubBranch=main
    ```
 
    This should update the version in `package.json` and `package-lock.json`, and


### PR DESCRIPTION
The vsce publish command assumes the wrong primary branch name. Updating
the RELEASING.md doc to include the flag to address the problem.